### PR TITLE
Add dnf support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
 install:
-  - pip install ansible==1.9.0
+  - pip install ansible==1.9.0.1
 script:
   - ansible --version
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check --list-tasks

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: python
 python: "2.7"
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl ansible
-#install:
-#  - pip install ansible==1.8.0
+ - sudo apt-get install -qq python-apt python-pycurl
+install:
+  - pip install ansible==1.9.0
 script:
   - ansible --version
-  - ansible-playbook -i tests/inventory tests/test.yml --syntax-check --list-tasks 
+  - ansible-playbook -i tests/inventory tests/test.yml --syntax-check --list-tasks
   - ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo
-  

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ ansible --version
 
 # OS
 case $OSTYPE in
-  # Linux needs apt|yum|zypper
+  # Linux needs apt|yum|dnf|zypper
   "linux"*)
-      apt --version||yum --version||zypper --version;;
+      apt --version||yum --version||dnf --version||zypper --version;;
   # OS X needs nothing
   "darwin"*)
       echo autofs is OOB;;

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Prescott Chris
   description: Installs and configures autofs
   license: BSD
-  min_ansible_version: 1.4.4
+  min_ansible_version: 1.9
   platforms:
   - name: GenericLinux
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,12 @@
   when: ansible_pkg_mgr == 'zypper'
 
 
+- name: "Setup | dnf | ensure autofs's package(s) present"
+  dnf: name="{{ item }}"
+  with_items: autofs_pkgs[ ansible_system ]
+  when: ansible_pkg_mgr == 'dnf'
+
+
 # ----- Config -----
 - name: "Config| all | ensure indirect map paths(s) exist"
   file: path="{{ item.path }}" state=directory
@@ -43,4 +49,3 @@
 - name: "Svc   |linux| ensure autofs starts at boot"
   service: name=autofs state=started enabled=yes
   when: ansible_system == 'Linux'
-


### PR DESCRIPTION
Dnf on Fedora 23 wasn't installing the autofs package and was erroring out during a run. I've not done any real testing other than 'it works on my machine'.
