### PR TITLE
allow for multiline "ansible_managed"-header

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
 
 
 - name: "Config| all | add indirect map file(s) to autofs master file"
-  lineinfile: dest="{{ autofs_master[ ansible_system ] }}" line="{{ item.path }}     {{ item.name }}"
+  lineinfile: dest="{{ autofs_master[ ansible_system ] }}" line="{{ item.path }}     /etc/{{ item.name }}"
   with_items: "{{ autofs_indirect_maps }}"
   notify: [ 'restart autofs', 'reload autofs']
 

--- a/templates/indirect_map.j2
+++ b/templates/indirect_map.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for mount in item.mounts %}
 {{ mount.name }} -fstype={{ mount.fstype }} {{ mount.url }}


### PR DESCRIPTION
Just a tiny change as described on http://docs.ansible.com/ansible/playbooks_filters.html
to make fileheaders easier to read.

May not be compatible with older versions of ansible.