### PR TITLE
allow for multiline "ansible_managed"-header

### DIFF
--- a/templates/indirect_map.j2
+++ b/templates/indirect_map.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for mount in item.mounts %}
 {{ mount.name }} -fstype={{ mount.fstype }} {{ mount.url }}


### PR DESCRIPTION
Just a tiny change as described on http://docs.ansible.com/ansible/playbooks_filters.html
to make fileheaders easier to read.

May not be compatible with older versions of ansible.