### PR TITLE
Add autofs options, which defaults to empty

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ autofs_master:
 autofs_indirect_maps: []
 #  - name: autofs.nfs
 #    path: /mnt/nfs
+#    options: ""
 #    mounts:
 #      - name: "isos" 
 #        fstype: "nfs,rw,bg,hard,intr,tcp,resvport"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
 
 
 - name: "Config| all | add indirect map file(s) to autofs master file"
-  lineinfile: dest="{{ autofs_master[ ansible_system ] }}" line="{{ item.path }}     {{ item.name }}"
+  lineinfile: dest="{{ autofs_master[ ansible_system ] }}" line="{{ item.path }}     {{ item.name }} {{ item.options | default ("") }}"
   with_items: "{{ autofs_indirect_maps }}"
   notify: [ 'restart autofs', 'reload autofs']
 


### PR DESCRIPTION
To enable automount options to auto.master.