### PR TITLE
Fix package manager warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,26 +4,22 @@
 
 # ----- Setup -----
 - name: "Setup | apt | ensure autofs's package(s) present"
-  apt: name="{{ item }}"
-  with_items: "{{ autofs_pkgs[ ansible_system ] }}"
+  apt: name="{{ autofs_pkgs[ ansible_system ] }}"
   when: ansible_pkg_mgr == 'apt'
 
 
 - name: "Setup | yum | ensure autofs's package(s) present"
-  yum: name="{{ item }}"
-  with_items: "{{ autofs_pkgs[ ansible_system ] }}"
+  yum: name="{{ autofs_pkgs[ ansible_system ] }}"
   when: ansible_pkg_mgr == 'yum'
 
 
 - name: "Setup | zyp | ensure autofs's package(s) present"
-  zypper: name="{{ item }}"
-  with_items: "{{ autofs_pkgs[ ansible_system ] }}"
+  zypper: name="{{ autofs_pkgs[ ansible_system ] }}"
   when: ansible_pkg_mgr == 'zypper'
 
 
 - name: "Setup | dnf | ensure autofs's package(s) present"
-  dnf: name="{{ item }}"
-  with_items: "{{ autofs_pkgs[ ansible_system ] }}"
+  dnf: name="{{ autofs_pkgs[ ansible_system ] }}"
   when: ansible_pkg_mgr == 'dnf'
 
 


### PR DESCRIPTION
Like this one:
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of 
using a loop to supply multiple items and specifying `name: {{ item }}`, please use `name: u'{{ autofs_pkgs[ 
ansible_system ] }}'` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be
 disabled by setting deprecation_warnings=False in ansible.cfg.